### PR TITLE
Setup Kafka multi-node cluster with KRaft mode

### DIFF
--- a/backend/services/gpt.sql
+++ b/backend/services/gpt.sql
@@ -39,8 +39,8 @@ CREATE TEMPORARY TABLE mouse_events_src (
 ) WITH (
   'connector' = 'kafka',
   'topic' = 'mouse_events',
-  'properties.bootstrap.servers' = 'sv_kafka:29092',
-  'properties.group.id' = 'flink-consumer-mouse-p8',
+  'properties.bootstrap.servers' = 'broker-1:19092,broker-2:19092,broker-3:19092',
+  'properties.group.id' = 'flink-consumer-mouse-p1',
   'scan.startup.mode' = 'latest-offset',                 -- 필요시 earliest-offset
   'scan.topic-partition-discovery.interval' = '60 s',
   'format' = 'json',
@@ -65,8 +65,8 @@ CREATE TEMPORARY TABLE keydown_events_src (
 ) WITH (
   'connector' = 'kafka',
   'topic' = 'keydown_events',
-  'properties.bootstrap.servers' = 'sv_kafka:29092',
-  'properties.group.id' = 'flink-consumer-key-p8',
+  'properties.bootstrap.servers' = 'broker-1:19092,broker-2:19092,broker-3:19092',
+  'properties.group.id' = 'flink-consumer-key-p1',
   'scan.startup.mode' = 'latest-offset',
   'scan.topic-partition-discovery.interval' = '60 s',
   'format' = 'json',

--- a/backend/tests/e2e_http_events.js
+++ b/backend/tests/e2e_http_events.js
@@ -32,7 +32,7 @@ export const options = {
         { duration: '20s', target: Math.ceil(RATE * 0.8) },
         { duration: '20s', target: RATE },
       ],
-      gracefulStop: '10s',
+      gracefulStop: '7s',
     },
     steady: {
       executor: 'constant-arrival-rate',
@@ -42,7 +42,7 @@ export const options = {
       preAllocatedVUs: PRE_VUS,
       maxVUs: MAX_VUS,
       startTime: '1m30s',
-      gracefulStop: '10s',
+      gracefulStop: '5s',
     },
   },
   thresholds: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -381,8 +381,8 @@ services:
     volumes:
       - ./backend/tests:/scripts:ro   # ← 여기에 e2e_http_events.js 두었죠
     environment:
-      - RATE=1000        # 총 EPS (원하는 값으로 수정/실행 시 -e로 override 가능)
-      - DURATION=5m       # 테스트 지속 시간
+      - RATE=20000        # 총 EPS (원하는 값으로 수정/실행 시 -e로 override 가능)
+      - DURATION=2m       # 테스트 지속 시간
       - URL=http://stream_writer:8000/api/events   # ← 같은 네트워크의 백엔드 서비스명
       - PRE_VUS=2000
       - MAX_VUS=8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,31 +83,155 @@ services:
       - minio
       - mc
 
-  kafka:
+  # --- Kafka: Controllers (3) ---
+  controller-1:
     image: apache/kafka:3.9.1
-    container_name: sv_kafka
-    ports:
-      - "9092:9092"
-      - "29092:29092"
-    environment:
-      KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_NODE_ID: 1
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@sv_kafka:9093
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://sv_kafka:29092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_INTERNAL://0.0.0.0:29092,CONTROLLER://0.0.0.0:9093
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT_INTERNAL
-      KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-      KAFKA_COMPRESSION_TYPE: zstd
-      KAFKA_LOG_RETENTION_MS: 86400000
-      KAFKA_NUM_PARTITIONS: 8
-      KAFKA_MESSAGE_MAX_BYTES: 1048576
-
+    container_name: controller-1
+    hostname: controller-1
     networks:
       iceberg_net:
-  
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: controller
+      KAFKA_LISTENERS: CONTROLLER://controller-1:9093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+    volumes:
+      - controller-1-data:/var/lib/kafka/data
+
+  controller-2:
+    image: apache/kafka:3.9.1
+    container_name: controller-2
+    hostname: controller-2
+    networks:
+      iceberg_net:
+    environment:
+      KAFKA_NODE_ID: 2
+      KAFKA_PROCESS_ROLES: controller
+      KAFKA_LISTENERS: CONTROLLER://controller-2:9093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+    volumes:
+      - controller-2-data:/var/lib/kafka/data
+
+  controller-3:
+    image: apache/kafka:3.9.1
+    container_name: controller-3
+    hostname: controller-3
+    networks:
+      iceberg_net:
+    environment:
+      KAFKA_NODE_ID: 3
+      KAFKA_PROCESS_ROLES: controller
+      KAFKA_LISTENERS: CONTROLLER://controller-3:9093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+    volumes:
+      - controller-3-data:/var/lib/kafka/data
+
+  # --- Kafka: Brokers (3) ---
+  broker-1:
+    image: apache/kafka:3.9.1
+    container_name: broker-1
+    depends_on: [controller-1, controller-2, controller-3]
+    networks:
+      iceberg_net:
+    ports: ["29092:9092"]
+    environment:
+      KAFKA_NODE_ID: 4
+      KAFKA_PROCESS_ROLES: broker
+      KAFKA_LISTENERS: PLAINTEXT://:19092,PLAINTEXT_HOST://:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker-1:19092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
+      KAFKA_MIN_INSYNC_REPLICAS: 2
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_NUM_PARTITIONS: 8
+      KAFKA_COMPRESSION_TYPE: zstd
+      KAFKA_MESSAGE_MAX_BYTES: 1048576
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_AUTO_LEADER_REBALANCE_ENABLE: "true"
+      KAFKA_LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS: 30
+      KAFKA_LEADER_IMBALANCE_PER_BROKER_PERCENTAGE: 10
+    volumes:
+      - broker-1-data:/var/lib/kafka/data
+
+  broker-2:
+    image: apache/kafka:3.9.1
+    container_name: broker-2
+    depends_on: [controller-1, controller-2, controller-3]
+    networks:
+      iceberg_net:
+    ports: ["39092:9092"]
+    environment:
+      KAFKA_NODE_ID: 5
+      KAFKA_PROCESS_ROLES: broker
+      KAFKA_LISTENERS: PLAINTEXT://:19092,PLAINTEXT_HOST://:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker-2:19092,PLAINTEXT_HOST://localhost:39092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
+      KAFKA_MIN_INSYNC_REPLICAS: 2
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_NUM_PARTITIONS: 8
+      KAFKA_COMPRESSION_TYPE: zstd
+      KAFKA_MESSAGE_MAX_BYTES: 1048576
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_AUTO_LEADER_REBALANCE_ENABLE: "true"
+      KAFKA_LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS: 30
+      KAFKA_LEADER_IMBALANCE_PER_BROKER_PERCENTAGE: 10
+    volumes:
+      - broker-2-data:/var/lib/kafka/data
+
+  broker-3:
+    image: apache/kafka:3.9.1
+    container_name: broker-3
+    depends_on: [controller-1, controller-2, controller-3]
+    networks:
+      iceberg_net:
+    ports: ["49092:9092"]
+    environment:
+      KAFKA_NODE_ID: 6
+      KAFKA_PROCESS_ROLES: broker
+      KAFKA_LISTENERS: PLAINTEXT://:19092,PLAINTEXT_HOST://:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker-3:19092,PLAINTEXT_HOST://localhost:49092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
+      KAFKA_MIN_INSYNC_REPLICAS: 2
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_NUM_PARTITIONS: 8
+      KAFKA_COMPRESSION_TYPE: zstd
+      KAFKA_MESSAGE_MAX_BYTES: 1048576
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_AUTO_LEADER_REBALANCE_ENABLE: "true"
+      KAFKA_LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS: 30
+      KAFKA_LEADER_IMBALANCE_PER_BROKER_PERCENTAGE: 10
+    volumes:
+      - broker-3-data:/var/lib/kafka/data
+
   kafka-ui:
     image: provectuslabs/kafka-ui:latest
     container_name: kafka-ui
@@ -115,9 +239,11 @@ services:
       - "8080:8080"
     environment:
       - KAFKA_CLUSTERS_0_NAME=local
-      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=sv_kafka:29092
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=broker-1:19092,broker-2:19092,broker-3:19092
     depends_on:
-      - kafka
+      - broker-1
+      - broker-2
+      - broker-3
     networks:
       iceberg_net:
 
@@ -127,10 +253,14 @@ services:
     container_name: stream_writer
     volumes:
       - ./backend:/app
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=broker-1:19092,broker-2:19092,broker-3:19092
     ports:
       - "8000:8000"
     depends_on:
-      - kafka
+      - broker-1
+      - broker-2
+      - broker-3
       - rest
       - minio
     networks:
@@ -251,7 +381,7 @@ services:
     volumes:
       - ./backend/tests:/scripts:ro   # ← 여기에 e2e_http_events.js 두었죠
     environment:
-      - RATE=10000        # 총 EPS (원하는 값으로 수정/실행 시 -e로 override 가능)
+      - RATE=1000        # 총 EPS (원하는 값으로 수정/실행 시 -e로 override 가능)
       - DURATION=5m       # 테스트 지속 시간
       - URL=http://stream_writer:8000/api/events   # ← 같은 네트워크의 백엔드 서비스명
       - PRE_VUS=2000
@@ -263,3 +393,11 @@ networks:
   iceberg_net:
     name: iceberg_net
     driver: bridge
+
+volumes:
+  controller-1-data:
+  controller-2-data:
+  controller-3-data:
+  broker-1-data:
+  broker-2-data:
+  broker-3-data:


### PR DESCRIPTION
### Summary
- Kafka 멀티 노드 클러스터(KRaft 모드) 환경을 구성했습니다.

### Details
- 3 Broker + 3 Controller 구조로 설정
- 부하테스트  수행 → 초당 10,000 EPS 처리 성공
- 
### Notes
- Zookeeper 미사용 (KRaft 기반)
